### PR TITLE
change solenoid dimension and scale field to max 2T

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -375,18 +375,18 @@ Examples:
     </documentation>
 
     <comment>Solenoid option (BaBar magnet)</comment>
+    <comment>
     <constant name="Solenoid_length"           value="3840.0*mm"/>
     <constant name="Solenoid_rmin"             value="1420.0*mm"/>
     <constant name="Solenoid_thickness"        value="350*mm"/>
     <constant name="Solenoid_offset"           value="-100*mm"/>
-
+    </comment>
+    
     <comment>Solenoid option (ATHENA design)</comment>
-    <comment>
     <constant name="Solenoid_length"           value="3840.0*mm"/>
     <constant name="Solenoid_rmin"             value="1600.0*mm"/>
     <constant name="Solenoid_thickness"        value="455*mm"/>
     <constant name="Solenoid_offset"           value="-240*mm"/>
-    </comment>
 
     <comment>Helmholtz option</comment>
     <comment>

--- a/compact/fields/marco.xml
+++ b/compact/fields/marco.xml
@@ -7,7 +7,7 @@
            field_map="fieldmaps/MARCO_v.6.4.1.1.3_1.7T_Magnetic_Field_Map_2022_11_14_rad_coords_cm_T.txt"
            url="https://github.com/eic/epic-data/raw/64b7ca6306b138b7f000e696c82bd8f72db1da56/MARCO_v.6.4.1.1.3_1.7T_Magnetic_Field_Map_2022_11_14_rad_coords_cm_T.txt"
            cache="$DETECTOR_PATH:/opt/detector"
-           scale="1.0">
+           scale="1.176">
       <dimensions>
         <R step="2.0*cm" min="0*cm" max="998*cm" />
         <Z step="2.0*cm" min="-800*cm" max="798*cm" />


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Change the solenoid dimension from the ePIC solenoid to ATHENA solenoid. Note that this is not the exact geometry of the ATHENA solenoid. The magnetic field is scaled from 1.7 T to 2T.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #1 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
Yes. Better momentum resolution in the central detector.
