### PR TITLE
added b0 omd zdc implementations

### DIFF
--- a/compact/definitions.xml
+++ b/compact/definitions.xml
@@ -311,6 +311,21 @@ The unused IDs below are saved for future use.
       Defined by putting 88- on each detector component ID of IP-6.
       #### (88150-88169) Far Forward Detectors
     </documentation>
+    <constant name="IP8_B0Tracker_Station_1_ID" value="88150"/>
+    <constant name="IP8_B0TrackerCompanion_ID"  value="88157"/>
+    <constant name="IP8_B0ECal_ID"              value="88169"/>
+
+    <constant name="IP8_ForwardOffMTracker_station_1_ID" value="88159"/>
+    <constant name="IP8_ForwardOffMTracker_station_2_ID" value="88160"/>
+    <constant name="IP8_ForwardOffMTracker_station_3_ID" value="88161"/>
+    <constant name="IP8_ForwardOffMTracker_station_4_ID" value="88162"/>    
+
+    <constant name="IP8_ZDC_1stSilicon_ID"  value="88163"/>
+    <constant name="IP8_ZDC_Crystal_ID"     value="88164"/>
+    <constant name="IP8_ZDC_WSi_ID"         value="88165"/>
+    <constant name="IP8_ZDC_PbSi_ID"        value="88166"/>
+    <constant name="IP8_ZDC_PbSci_ID"       value="88167"/>
+
     <constant name="IP8_SimpleRomanPot3_ID"  value="88155"/>
     <constant name="IP8_SimpleRomanPot4_ID"  value="88156"/>
 

--- a/compact/far_forward/B0_ECal_ip8.xml
+++ b/compact/far_forward/B0_ECal_ip8.xml
@@ -1,0 +1,75 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+<!-- Copyright (C) 2022 Sakib Rahman -->
+<!-- Modified based on IP-8 information Jihee Kim-->
+
+<lccdd>
+  <define>
+    <constant name="B0ECal_rotation" value="ionCrossingAngle"/>
+    <constant name="B0ECal_IP_distance" value="683*cm"/>
+    <constant name="B0ECal_xcenter" value="B0ECal_IP_distance*sin(ionCrossingAngle)"/>
+    <constant name="B0ECal_zcenter" value="B0ECal_IP_distance*cos(ionCrossingAngle)"/>
+    <constant name="B0ECal_length" value="10*cm"/>
+    <constant name="B0ECal_CrystalModule_width" value="2*cm"/>
+    <constant name="B0ECal_CrystalModule_length" value="B0ECal_length"/>
+    <constant name="B0ECal_CrystalModule_wrap" value="0.50*mm"/>
+    <!--<constant name="B0ECal_packman_rmin" value="3.3*cm"/>-->
+    <constant name="B0ECal_packman_rmin" value="3.7*cm"/>
+    <constant name="B0ECal_packman_small_rmax" value="8*cm"/>
+    <constant name="B0ECal_packman_large_rmax" value="15*cm"/>
+    <constant name="B0ECal_packman_large_phimin" value="-120*deg"/>
+    <constant name="B0ECal_packman_large_phimax" value="120*deg"/>
+    <constant name="B0ECal_r_envelopeclearance" value="1*mm+(B0ECal_CrystalModule_width+2*B0ECal_CrystalModule_wrap)*sqrt(2)"/>
+    <constant name="B0ECal_phi_envelopeclearance" value="(3.0*(B0ECal_CrystalModule_width+2*B0ECal_CrystalModule_wrap)*sqrt(2))/B0ECal_packman_small_rmax"/>
+  </define>
+
+  <detectors>
+
+    <documentation>
+      #### B0 Electromagnetic Calorimeter
+    </documentation>
+    <detector
+        id="IP8_B0ECal_ID"
+        name="B0ECal"
+        type="B0_ECAL"
+        readout="IP8B0ECalHits">
+      <position x="B0ECal_xcenter" y="0" z="B0ECal_zcenter"/>
+      <rotation x="B0ECal_rotation" y="180*deg" z="180.0*deg"/>
+      <placements>
+        <disk
+            rmin="B0ECal_packman_rmin"
+            rintermediate="B0ECal_packman_small_rmax"
+            rmax="B0ECal_packman_large_rmax"
+            phimin="B0ECal_packman_large_phimin"
+            phimax="B0ECal_packman_large_phimax"
+            envelope="false"
+            r_envelopeclearance="B0ECal_r_envelopeclearance"
+            phi_envelopeclearance="B0ECal_phi_envelopeclearance"
+            material="Vacuum"
+            sector="1">
+          <module
+            sizex="B0ECal_CrystalModule_width"
+            sizey="B0ECal_CrystalModule_width"
+            sizez="B0ECal_CrystalModule_length"
+            vis="GreenVis"
+            material="PbWO4"/>
+          <wrapper
+            thickness="B0ECal_CrystalModule_wrap"
+            material="Epoxy"
+            vis="GrayVis"/>
+        </disk>
+      </placements>
+
+    </detector>
+
+  </detectors>
+
+  <readouts>
+    <comment>
+      No segmentation since module is the smallest readout segmentation
+    </comment>
+    <readout name="IP8B0ECalHits">
+      <segmentation type="NoSegmentation" key="sector"/>
+      <id>system:8,sector:4,module:20</id>
+    </readout>
+  </readouts>
+</lccdd>

--- a/compact/far_forward/B0_tracker_ip8.xml
+++ b/compact/far_forward/B0_tracker_ip8.xml
@@ -1,0 +1,184 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+<!-- Copyright (C) 2022 Whitney Armstrong, Alex Jentsch -->
+<!-- Modified based on IP-8 information Jihee Kim-->
+
+<lccdd>
+  <define>
+    <comment>
+      ### B0 Tracker Parameters
+    </comment>
+
+    <comment>
+      - The detector length based on the 0.2*m step size and 4 layers.
+      - I start from the downstream side of the B0 magnet and an arbitrary offset
+        which puts the downstream of the detector 10cm from the end of the magnet.
+    </comment>
+    <constant name="B0Tracker_length"      value="81.0*cm"/>
+    <constant name="B0Tracker_zoffset"     value="5.0*cm"/>
+    <constant name="B0TrackerCenter_zpos"  value="6.3*m"/>
+    <constant name="B0TrackerCenter_xpos"  value="B0TrackerCenter_zpos*sin(ionCrossingAngle)" />
+    <constant name="B0Tracker_zmin"        value="B0TrackerCenter_zpos - B0Tracker_length/2.0 "/>
+    <constant name="B0Tracker_rotation"    value="ionCrossingAngle"/>
+    <comment>
+      average of station 2 and 3 x postions below...
+    </comment>
+    <constant name="B0TrackerSlope_x" value="0.0249974*m" />
+    <constant name="B0Tracker_nlayers"   value="4"/>
+    <constant name="B0Tracker_dz"        value="B0Tracker_length/(B0Tracker_nlayers-1)"/>
+    <constant name="B0TrackerLayer1_zstart" value="-B0Tracker_length/2.0"/>
+    <constant name="B0TrackerLayer2_zstart" value="-B0Tracker_length/2.0+B0Tracker_dz"/>
+    <constant name="B0TrackerLayer3_zstart" value="-B0Tracker_length/2.0+2*B0Tracker_dz"/>
+    <constant name="B0TrackerLayer4_zstart" value="-B0Tracker_length/2.0+3*B0Tracker_dz"/>
+
+    <comment>
+      This angle is the angle subtended in phi for each trap segment.
+    </comment>
+    <constant name="B0TrackerLayer_nModules"          value="36"/>
+    <constant name="B0TrackerLayerSmallMod_nModules"  value="B0TrackerLayer_nModules/6"/>
+    <constant name="B0TrackerModOpeningAngle"         value="360.0*degree/B0TrackerLayer_nModules"/>
+    <constant name="B0TrackerLayerBigMod_nModules"    value="B0TrackerLayer_nModules - B0TrackerLayerSmallMod_nModules"/>
+    <constant name="B0TrackerLayerBigMod_phi0"        value="(B0TrackerLayerSmallMod_nModules/2.0 + 0.5)*B0TrackerModOpeningAngle + Pi"/>
+    <constant name="B0TrackerLayerSmallMod_phi0"        value="(B0TrackerLayerSmallMod_nModules/2.0 - 0.5)*B0TrackerModOpeningAngle + Pi"/>
+
+    <constant name="B0TrackerMod1Inner_z"      value="1.0*cm" />
+    <!--<constant name="B0TrackerMod1Inner_r"      value="3.0*cm" />-->
+    <constant name="B0TrackerMod1Inner_r"      value="3.5*cm" />
+    <constant name="B0TrackerMod1Outer_r"      value="15.0*cm"/>
+    <constant name="B0TrackerMod1_x1"          value="2.0*B0TrackerMod1Inner_r*sin(B0TrackerModOpeningAngle/2.0)"/>
+    <constant name="B0TrackerMod1_x2"          value="2.0*B0TrackerMod1Outer_r*sin(B0TrackerModOpeningAngle/2.0)"/>
+    <constant name="B0TrackerMod1_y"           value="B0TrackerMod1Outer_r*cos(B0TrackerModOpeningAngle/2.0) - B0TrackerMod1Inner_r"/>
+
+    <constant name="B0TrackerMod1SmallOuter_r" value="10.0*cm"/>
+    <constant name="B0TrackerMod1Small_x2"     value="2.0*B0TrackerMod1SmallOuter_r*sin(B0TrackerModOpeningAngle/2.0)"/>
+    <constant name="B0TrackerMod1Small_y"      value="B0TrackerMod1SmallOuter_r*cos(B0TrackerModOpeningAngle/2.0) - B0TrackerMod1Inner_r"/>
+
+    <constant name="B0TrackerMod2SmallOuter_r" value="10.0*cm"/>
+    <constant name="B0TrackerMod2Small_x2"     value="2.0*B0TrackerMod2SmallOuter_r*sin(B0TrackerModOpeningAngle/2.0)"/>
+    <constant name="B0TrackerMod2Small_y"      value="B0TrackerMod2SmallOuter_r*cos(B0TrackerModOpeningAngle/2.0) - B0TrackerMod1Inner_r"/>
+
+    <constant name="B0TrackerMod3SmallOuter_r" value="11.0*cm"/>
+    <constant name="B0TrackerMod3Small_x2"     value="2.0*B0TrackerMod3SmallOuter_r*sin(B0TrackerModOpeningAngle/2.0)"/>
+    <constant name="B0TrackerMod3Small_y"      value="B0TrackerMod3SmallOuter_r*cos(B0TrackerModOpeningAngle/2.0) - B0TrackerMod1Inner_r"/>
+
+    <constant name="B0TrackerMod4SmallOuter_r" value="12.0*cm"/>
+    <constant name="B0TrackerMod4Small_x2"     value="2.0*B0TrackerMod4SmallOuter_r*sin(B0TrackerModOpeningAngle/2.0)"/>
+    <constant name="B0TrackerMod4Small_y"      value="B0TrackerMod4SmallOuter_r*cos(B0TrackerModOpeningAngle/2.0) - B0TrackerMod1Inner_r"/>
+
+  </define>
+
+  <detectors>
+    <detector
+      id="IP8_B0TrackerCompanion_ID"
+      name="B0TrackerCompanion"
+      type="D2EIC_CompositeTracker"
+      actsType="endcap"
+      vis="TrackerSubAssemblyVis">
+      <type_flags type="DetType_TRACKER + DetType_ENDCAP"/>
+      <position x="0*cm" y="0*cm" z="-4*um" />
+    </detector>
+
+    <detector
+      id="IP8_B0Tracker_Station_1_ID"
+      name="B0Tracker"
+      type="ip6_B0Tracker"
+      readout="IP8B0TrackerHits"
+      vis="FFTrackerVis">
+      <type_flags type="DetType_TRACKER + DetType_ENDCAP"/>
+      <position x="B0TrackerCenter_xpos" y="0" z="B0TrackerCenter_zpos"/>
+      <rotation x="0*rad" y="B0Tracker_rotation" z="180.0*deg"/>
+      <module name="Module1" vis="TrackerModuleVis"> <!-- AnlProcess_Blue-->
+        <trd x1="B0TrackerMod1_x1/2.0" x2="B0TrackerMod1_x2/2.0" z="B0TrackerMod1_y/2"/>
+        <comment> Back-to-front </comment>
+        <module_component thickness="0.715*mm" material="Copper" vis="FFTrackerSupportVis" />
+        <module_component thickness="0.3*mm" material="SiliconOxide" vis="FFTrackerSurfaceVis" sensitive="true"/>
+      </module>
+      <module name="SmallModule1" vis="FFTrackerModuleVis">
+        <trd x1="B0TrackerMod1_x1/2.0" x2="B0TrackerMod1Small_x2/2.0" z="B0TrackerMod1Small_y/2"/>
+        <module_component thickness="0.715*mm" material="Copper" vis="FFTrackerSupportVis" />
+        <module_component thickness="0.3*mm" material="SiliconOxide" vis="FFTrackerSurfaceVis" sensitive="true"/>
+      </module>
+      <module name="SmallModule2" vis="FFTrackerModuleVis">
+        <trd x1="B0TrackerMod1_x1/2.0" x2="B0TrackerMod2Small_x2/2.0" z="B0TrackerMod2Small_y/2"/>
+        <module_component thickness="0.715*mm" material="Copper" vis="FFTrackerSupportVis" />
+        <module_component thickness="0.3*mm" material="SiliconOxide" vis="FFTrackerSurfaceVis" sensitive="true"/>
+      </module>
+      <module name="SmallModule3" vis="FFTrackerModuleVis">
+        <trd x1="B0TrackerMod1_x1/2.0" x2="B0TrackerMod3Small_x2/2.0" z="B0TrackerMod3Small_y/2"/>
+        <module_component thickness="0.715*mm" material="Copper" vis="FFTrackerSupportVis" />
+        <module_component thickness="0.3*mm" material="SiliconOxide" vis="FFTrackerSurfaceVis" sensitive="true"/>
+      </module>
+      <module name="SmallModule4" vis="FFTrackerModuleVis">
+        <trd x1="B0TrackerMod1_x1/2.0" x2="B0TrackerMod4Small_x2/2.0" z="B0TrackerMod4Small_y/2"/>
+        <module_component thickness="0.715*mm" material="Copper" vis="FFTrackerSupportVis" />
+        <module_component thickness="0.3*mm" material="SiliconOxide" vis="FFTrackerSurfaceVis" sensitive="true"/>
+      </module>
+      <layer id="1">
+        <envelope  vis="FFTrackerLayerVis" rmin_tolerance="0*mm" rmax_tolerance="0*mm"
+                   zmin_tolerance="0*mm" zmax_tolerance="0*mm" length="1.0*cm"
+                   zstart="B0TrackerLayer1_zstart" />
+        <ring phi0="B0TrackerLayerBigMod_phi0" dphi="B0TrackerModOpeningAngle"
+          r="B0TrackerMod1Inner_r+B0TrackerMod1_y/2.0" zstart="0.0*mm"
+          nmodules="B0TrackerLayerBigMod_nModules" dz="0 * mm" module="Module1" />
+        <ring phi0="-B0TrackerLayerSmallMod_phi0" dphi="B0TrackerModOpeningAngle"
+          r="B0TrackerMod1Inner_r+B0TrackerMod1Small_y/2.0" zstart="0.0*mm"
+          nmodules="B0TrackerLayerSmallMod_nModules" dz="0 * mm" module="SmallModule1" />
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*(B0TrackerLayerSmallMod_nModules)" bins1="256"/>
+      </layer>
+      <layer id="2" >
+        <envelope vis="FFTrackerLayerVis" rmin_tolerance="0*mm" rmax_tolerance="0*mm"
+                  zmin_tolerance="0*mm" zmax_tolerance="0*mm" length="1.0*cm"
+                  zstart="B0TrackerLayer2_zstart" />
+        <ring phi0="B0TrackerLayerBigMod_phi0" dphi="B0TrackerModOpeningAngle"
+          r="B0TrackerMod1Inner_r+B0TrackerMod1_y/2.0" zstart="0.0*mm"
+          nmodules="B0TrackerLayerBigMod_nModules" dz="0 * mm" module="Module1" />
+        <ring phi0="-B0TrackerLayerSmallMod_phi0" dphi="B0TrackerModOpeningAngle"
+          r="B0TrackerMod1Inner_r+B0TrackerMod2Small_y/2.0" zstart="0.0*mm"
+          nmodules="B0TrackerLayerSmallMod_nModules" dz="0 * mm" module="SmallModule2" />
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*(B0TrackerLayerSmallMod_nModules)" bins1="256"/>
+      </layer>
+      <layer id="3" >
+        <envelope vis="FFTrackerLayerVis" rmin_tolerance="0*mm" rmax_tolerance="0*mm"
+                  zmin_tolerance="0*mm" zmax_tolerance="0*mm" length="1.0*cm"
+                  zstart="B0TrackerLayer3_zstart" />
+        <ring phi0="B0TrackerLayerBigMod_phi0" dphi="B0TrackerModOpeningAngle"
+          r="B0TrackerMod1Inner_r+B0TrackerMod1_y/2.0" zstart="0.0*mm"
+          nmodules="B0TrackerLayerBigMod_nModules" dz="0 * mm" module="Module1" />
+        <ring phi0="-B0TrackerLayerSmallMod_phi0" dphi="B0TrackerModOpeningAngle"
+          r="B0TrackerMod1Inner_r+B0TrackerMod3Small_y/2.0" zstart="0.0*mm"
+          nmodules="B0TrackerLayerSmallMod_nModules" dz="0 * mm" module="SmallModule3" />
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*(B0TrackerLayerSmallMod_nModules)" bins1="256"/>
+      </layer>
+      <layer id="4" >
+        <envelope vis="FFTrackerLayerVis" rmin_tolerance="0*mm" rmax_tolerance="0*mm"
+                  zmin_tolerance="0*cm" zmax_tolerance="0*cm" length="1.0*cm"
+                  zstart="B0TrackerLayer4_zstart" />
+        <ring phi0="B0TrackerLayerBigMod_phi0" dphi="B0TrackerModOpeningAngle"
+          r="B0TrackerMod1Inner_r+B0TrackerMod1_y/2.0" zstart="0.0*mm"
+          nmodules="B0TrackerLayerBigMod_nModules" dz="0 * mm" module="Module1" />
+        <ring phi0="-B0TrackerLayerSmallMod_phi0" dphi="B0TrackerModOpeningAngle"
+          r="B0TrackerMod1Inner_r+B0TrackerMod4Small_y/2.0" zstart="0.0*mm"
+          nmodules="B0TrackerLayerSmallMod_nModules" dz="0 * mm" module="SmallModule4" />
+        <layer_material surface="inner" binning="binPhi,binR" bins0="20*(B0TrackerLayerSmallMod_nModules)" bins1="256"/>
+      </layer>
+    </detector>
+
+  </detectors>
+
+  <readouts>
+    <readout name="IP8B0TrackerHits">
+      <comment>
+        20um resolution = 75um "pixels", but this is "effective", since we assume charge sharing in the real-life 500um AC-LGADs - this may need to addressed differently in simulations later via digitization
+      </comment>
+      <segmentation type="CartesianGridXZ" grid_size_x="0.070*mm" grid_size_z="0.070*mm" />
+      <id>system:8,layer:4,module:12,sensor:2,x:32:-16,z:-16</id>
+    </readout>
+  </readouts>
+
+  <plugins>
+    <plugin name="DD4hep_ParametersPlugin">
+      <argument value="B0Tracker"/>
+      <argument value="layer_pattern: str=B0Tracker_layer\d"/>
+    </plugin>
+  </plugins>
+
+</lccdd>

--- a/compact/far_forward/ZDC_1stSilicon_ip8.xml
+++ b/compact/far_forward/ZDC_1stSilicon_ip8.xml
@@ -1,0 +1,44 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+<!-- Copyright (C) 2022 Shima Shimizu -->
+<!-- Modified based on IP-8 information Jihee Kim-->
+
+<lccdd>
+  <comment>
+    //////////////////////////////////////////////////
+    // Far Forward Zero Degree Calorimeter
+    //////////////////////////////////////////////////
+  </comment>
+
+  <define>
+    <constant name="ZDC_1stSilicon_x"       value="ZDC_width"/>
+    <constant name="ZDC_1stSilicon_y"       value="ZDC_width"/>
+    <constant name="ZDC_1stSilicon_z"       value="ZDC_pixel_thickness + ZDC_glue_thickness + ZDC_PCB_thickness + ZDC_Si_Air_thickness"/>
+  </define>
+
+  <detectors>
+    <detector
+        id="IP8_ZDC_1stSilicon_ID"
+        name="ZDC_1stSilicon"
+        type="ZDC_ImagingCal"
+        vis="ZDC_SiliconPix_Vis"
+        readout="IP8ZDC_SiliconPix_Hits">
+      <position x="ZDC_1stSilicon_x_pos"         y="ZDC_1stSilicon_y_pos"         z="ZDC_1stSilicon_z_pos"/>
+      <rotation x="ZDC_1stSilicon_rotateX_angle" y="ZDC_1stSilicon_rotateY_angle" z="ZDC_1stSilicon_rotateZ_angle"/>
+      <dimensions x="ZDC_1stSilicon_x" y="ZDC_1stSilicon_y" z="ZDC_1stSilicon_z"/>
+      <layer nlayer="1" gapspace="ZDC_Si_Air_thickness">
+        <slice name="silicon" material="Silicon" thickness="ZDC_pixel_thickness" vis="AnlRed"  sensitive="true"/>
+        <slice name="glue"  material="G10"     thickness="ZDC_glue_thickness"  vis="AnlLight_Gray"/>
+        <slice name="pcb"   material="ZDC_PET" thickness="ZDC_PCB_thickness"   vis="AnlGreen"/>
+      </layer>
+
+    </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="IP8ZDC_SiliconPix_Hits">
+      <segmentation type="CartesianGridXY" grid_size_x="3.*mm" grid_size_y="3.*mm"/>
+      <id>system:8,silicon:6,x:24:-12,y:-12</id>
+    </readout>
+  </readouts>
+
+</lccdd>

--- a/compact/far_forward/ZDC_Crystal_ip8.xml
+++ b/compact/far_forward/ZDC_Crystal_ip8.xml
@@ -1,0 +1,57 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+<!-- Copyright (C) 2022 Shima Shimizu -->
+<!-- Modified based on IP-8 information Jihee Kim-->
+
+<lccdd>
+  <comment>
+    //////////////////////////////////////////////////
+    // Far Forward Zero Degree Calorimeter
+    // Crystal calorimeter
+    //////////////////////////////////////////////////
+  </comment>
+
+  <define>
+    <constant name="ZDC_Crystal_cell_width"     value="3.*cm"/>
+    <constant name="ZDC_Crystal_cell_length"    value="7.*cm"/>
+    <constant name="ZDC_Crystal_frame_thickness"  value="0.3*mm"/>
+    <constant name="ZDC_Crystal_active_x"       value="ZDC_width"/>
+    <constant name="ZDC_Crystal_active_y"       value="ZDC_width"/>
+    <constant name="ZDC_Crystal_nx"             value="ZDC_Crystal_active_x/ZDC_Crystal_cell_width"/>
+    <constant name="ZDC_Crystal_ny"             value="ZDC_Crystal_active_y/ZDC_Crystal_cell_width"/>
+    <constant name="ZDC_Crystal_APD_socket_z"   value="2.5*mm"/>
+    <constant name="ZDC_Crystal_space"          value="2.8*cm"/>
+  </define>
+
+  <detectors>
+    <detector
+        id="IP8_ZDC_Crystal_ID"
+        name="ZDC_Crystal"
+        type="ZDC_Crystal"
+        vis="ZDC_Crystal_Vis"
+        readout="IP8ZDCEcalHits">
+      <position x="ZDC_Crystal_x_pos"         y="ZDC_Crystal_y_pos"         z="ZDC_Crystal_z_pos"/>
+      <rotation x="ZDC_Crystal_rotateX_angle" y="ZDC_Crystal_rotateY_angle" z="ZDC_Crystal_rotateZ_angle"/>
+      <dimensions x="ZDC_Crystal_nx * (ZDC_Crystal_cell_width + ZDC_Crystal_frame_thickness) + ZDC_Crystal_frame_thickness"
+                  y="ZDC_Crystal_ny * (ZDC_Crystal_cell_width + ZDC_Crystal_frame_thickness) + ZDC_Crystal_frame_thickness"
+                  z="ZDC_Crystal_cell_length + ZDC_Crystal_space"/>
+      <module name="tower" nx="ZDC_Crystal_nx" ny="ZDC_Crystal_ny">
+        <tower name="crystal"
+               cellx="ZDC_Crystal_cell_width" celly="ZDC_Crystal_cell_width" thickness="ZDC_Crystal_cell_length"
+               material="PbWO4" vis="AnlGold" sensitive="true"/>
+        <socket name="socket"
+                cellx="ZDC_Crystal_cell_width" celly="ZDC_Crystal_cell_width" thickness="ZDC_Crystal_APD_socket_z"
+                material="ZDC_Polyethylene" vis="AnlTeal" />
+      </module>
+      <support  material="CarbonFiber" vis="AnlLight_Gray" sizez="ZDC_Crystal_cell_length" thickness="ZDC_Crystal_frame_thickness"/>
+
+    </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="IP8ZDCEcalHits">
+      <segmentation type="NoSegmentation"/>
+      <id>system:8,module:2,crystal:12</id>
+    </readout>
+  </readouts>
+
+</lccdd>

--- a/compact/far_forward/ZDC_PbScinti_ip8.xml
+++ b/compact/far_forward/ZDC_PbScinti_ip8.xml
@@ -1,0 +1,46 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+<!-- Copyright (C) 2022 Shima Shimizu -->
+<!-- Modified based on IP-8 information Jihee Kim-->
+
+<lccdd>
+  <comment>
+    //////////////////////////////////////////////////
+    // Far Forward Zero Degree Calorimeter
+    //////////////////////////////////////////////////
+  </comment>
+
+  <define>
+    <constant name="ZDC_PbSci_layer_thickness" value="ZDC_Lead_thickness + ZDC_Sci_thickness"/>
+    <constant name="ZDC_PbSci_x"       value="ZDC_width"/>
+    <constant name="ZDC_PbSci_y"       value="ZDC_width"/>
+    <constant name="ZDC_PbSci_z"
+              value="ZDC_PbSci_nbox * (ZDC_PbSci_nlayers_per_box * ZDC_PbSci_layer_thickness + ZDC_PbSci_box_gap)"/>
+  </define>
+
+  <detectors>
+    <detector
+        id="IP8_ZDC_PbSci_ID"
+        name="ZDC_PbSci"
+        type="ZDC_SamplingCal"
+        vis="ZDC_PbSci_Vis"
+        readout="IP8ZDCHcalHits">
+      <position x="ZDC_PbSci_x_pos"         y="ZDC_PbSci_y_pos"         z="ZDC_PbSci_z_pos"/>
+      <rotation x="ZDC_PbSci_rotateX_angle" y="ZDC_PbSci_rotateY_angle" z="ZDC_PbSci_rotateZ_angle"/>
+      <dimensions x="ZDC_PbSci_x" y="ZDC_PbSci_y" z="ZDC_PbSci_z"/>
+      <module nbox="ZDC_PbSci_nbox" gapspace="ZDC_PbSci_box_gap">
+        <layer nlayer="ZDC_PbSci_nlayers_per_box">
+          <slice name="lead"      material="Lead"    thickness="ZDC_Lead_thickness"  vis="AnlLight_Gray"/>
+          <slice name="scinti"    material="ZDC_Scintillator" thickness="ZDC_Sci_thickness"   vis="AnlGreen"  sensitive="true"/>
+        </layer>
+      </module>
+    </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="IP8ZDCHcalHits">
+      <segmentation type="CartesianGridXY" grid_size_x="10.*cm" grid_size_y="10.*cm"/>
+      <id>system:8,scinti:6,x:24:-12,y:-12</id>
+    </readout>
+  </readouts>
+
+</lccdd>

--- a/compact/far_forward/ZDC_PbSi_ip8.xml
+++ b/compact/far_forward/ZDC_PbSi_ip8.xml
@@ -1,0 +1,47 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+<!-- Copyright (C) 2022 Shima Shimizu -->
+<!-- Modified based on IP-8 information Jihee Kim-->
+
+<lccdd>
+  <comment>
+    //////////////////////////////////////////////////
+    // Far Forward Zero Degree Calorimeter
+    //////////////////////////////////////////////////
+  </comment>
+
+  <define>
+    <constant name="ZDC_PbSi_layer_thickness"
+              value="ZDC_Lead_thickness + ZDC_glue_thickness * 2 + ZDC_pad_thickness + ZDC_PCB_thickness + ZDC_Si_Air_thickness"/>
+    <constant name="ZDC_PbSi_x"       value="ZDC_width"/>
+    <constant name="ZDC_PbSi_y"       value="ZDC_width"/>
+    <constant name="ZDC_PbSi_z"       value="ZDC_PbSi_nlayers * ZDC_PbSi_layer_thickness"/>
+  </define>
+
+  <detectors>
+    <detector
+        id="IP8_ZDC_PbSi_ID"
+        name="ZDC_PbSi"
+        type="ZDC_ImagingCal"
+        vis="ZDC_PbSi_Vis"
+        readout="IP8ZDC_PbSi_Hits">
+      <position x="ZDC_PbSi_x_pos"         y="ZDC_PbSi_y_pos"         z="ZDC_PbSi_z_pos"/>
+      <rotation x="ZDC_PbSi_rotateX_angle" y="ZDC_PbSi_rotateY_angle" z="ZDC_PbSi_rotateZ_angle"/>
+      <dimensions x="ZDC_PbSi_x" y="ZDC_PbSi_y" z="ZDC_PbSi_z"/>
+      <layer nlayer="ZDC_PbSi_nlayers" gapspace="ZDC_Si_Air_thickness">
+        <slice name="lead"      material="Lead"    thickness="ZDC_Lead_thickness"  vis="AnlLight_Gray"/>
+        <slice name="glue"      material="G10"     thickness="ZDC_glue_thickness"  vis="AnlLight_Gray"/>
+        <slice name="silicon"   material="Silicon" thickness="ZDC_pad_thickness"   vis="AnlTeal"  sensitive="true"/>
+        <slice name="glue"      material="G10"     thickness="ZDC_glue_thickness"  vis="AnlLight_Gray"/>
+        <slice name="pcb"       material="ZDC_PET" thickness="ZDC_PCB_thickness"   vis="AnlGreen"/>
+      </layer>
+    </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="IP8ZDC_PbSi_Hits">
+      <segmentation type="CartesianGridXY" grid_size_x="1.*cm" grid_size_y="1.*cm"/>
+      <id>system:8,silicon:6,x:24:-12,y:-12</id>
+    </readout>
+  </readouts>
+
+</lccdd>

--- a/compact/far_forward/ZDC_WSi_ip8.xml
+++ b/compact/far_forward/ZDC_WSi_ip8.xml
@@ -1,0 +1,85 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+<!-- Copyright (C) 2022 Shima Shimizu -->
+<!-- Modified based on IP-8 information Jihee Kim-->
+
+<lccdd>
+  <comment>
+    //////////////////////////////////////////////////
+    // Far Forward Zero Degree Calorimeter
+    //////////////////////////////////////////////////
+  </comment>
+
+  <define>
+    <constant name="ZDC_WSi_x"       value="ZDC_width"/>
+    <constant name="ZDC_WSi_y"       value="ZDC_width"/>
+    <constant name="ZDC_WSi_pix_nlayers" value="ZDC_WSi_nblocks + 1"/>
+    <constant name="ZDC_WSi_pad_nlayers" value="ZDC_WSi_nblocks * ZDC_WSi_pad_nlayers_per_block"/>
+    <constant name="ZDC_WSi_pad_layerthickness"
+              value="ZDC_Tungsten_thickness + ZDC_glue_thickness + ZDC_pad_thickness + ZDC_glue_thickness + ZDC_PCB_thickness + ZDC_Si_Air_thickness"/>
+    <constant name="ZDC_WSi_pixel_layerthickness"
+              value="ZDC_Tungsten_thickness + ZDC_glue_thickness + ZDC_pixel_thickness + ZDC_glue_thickness + ZDC_PCB_thickness + ZDC_Si_Air_thickness"/>
+    <constant name="ZDC_WSi_z"
+              value="ZDC_WSi_pix_nlayers * ZDC_WSi_pixel_layerthickness - ZDC_Tungsten_thickness - ZDC_glue_thickness + ZDC_WSi_pad_nlayers * ZDC_WSi_pad_layerthickness"/>
+  </define>
+
+  <detectors>
+    <detector
+        id="IP8_ZDC_WSi_ID"
+        name="ZDC_WSi"
+        type="ZDC_ImagingCal"
+        vis="ZDC_WSi_Vis"
+        readout="IP8_ZDC_WSi_Hits">
+      <position x="ZDC_WSi_x_pos"         y="ZDC_WSi_y_pos"         z="ZDC_WSi_z_pos"/>
+      <rotation x="ZDC_WSi_rotateX_angle" y="ZDC_WSi_rotateY_angle" z="ZDC_WSi_rotateZ_angle"/>
+      <dimensions x="ZDC_WSi_x" y="ZDC_WSi_y" z="ZDC_WSi_z"/>
+      <layer id="1" nlayer="1" gapspace="ZDC_Si_Air_thickness">
+        <slice name="silicon" material="Silicon" thickness="ZDC_pixel_thickness" vis="AnlRed"  sensitive="true"/>
+        <slice name="glue"  material="G10"     thickness="ZDC_glue_thickness"  vis="AnlLight_Gray"/>
+        <slice name="pcb"   material="ZDC_PET" thickness="ZDC_PCB_thickness"   vis="AnlGreen"/>
+      </layer>
+      <layer id="2" nlayer="ZDC_WSi_pad_nlayers_per_block" gapspace="ZDC_Si_Air_thickness">
+        <slice name="tungsten"  material="ZDC_Tungsten"     thickness="ZDC_Tungsten_thickness"  vis="AnlLight_Gray"/>
+        <slice name="glue"      material="G10"     thickness="ZDC_glue_thickness"  vis="AnlLight_Gray"/>
+        <slice name="silicon"    material="Silicon" thickness="ZDC_pad_thickness"   vis="AnlTeal"  sensitive="true"/>
+        <slice name="glue"      material="G10"     thickness="ZDC_glue_thickness"  vis="AnlLight_Gray"/>
+        <slice name="pcb"       material="ZDC_PET" thickness="ZDC_PCB_thickness"   vis="AnlGreen"/>
+      </layer>
+      <layer id="3" nlayer="1" gapspace="ZDC_Si_Air_thickness">
+        <slice name="tungsten"  material="ZDC_Tungsten"     thickness="ZDC_Tungsten_thickness"  vis="AnlLight_Gray"/>
+        <slice name="glue"      material="G10"     thickness="ZDC_glue_thickness"  vis="AnlLight_Gray"/>
+        <slice name="silicon"   material="Silicon" thickness="ZDC_pixel_thickness"   vis="AnlRed"  sensitive="true"/>
+        <slice name="glue"      material="G10"     thickness="ZDC_glue_thickness"  vis="AnlLight_Gray"/>
+        <slice name="pcb"       material="ZDC_PET" thickness="ZDC_PCB_thickness"   vis="AnlGreen"/>
+      </layer>
+      <layer id="4" nlayer="ZDC_WSi_pad_nlayers_per_block" gapspace="ZDC_Si_Air_thickness">
+        <slice name="tungsten"  material="ZDC_Tungsten"     thickness="ZDC_Tungsten_thickness"  vis="AnlLight_Gray"/>
+        <slice name="glue"      material="G10"     thickness="ZDC_glue_thickness"  vis="AnlLight_Gray"/>
+        <slice name="silicon"   material="Silicon" thickness="ZDC_pad_thickness"   vis="AnlTeal"  sensitive="true"/>
+        <slice name="glue"      material="G10"     thickness="ZDC_glue_thickness"  vis="AnlLight_Gray"/>
+        <slice name="pcb"       material="ZDC_PET" thickness="ZDC_PCB_thickness"   vis="AnlGreen"/>
+      </layer>
+      <layer id="5" nlayer="1" gapspace="ZDC_Si_Air_thickness">
+        <slice name="tungsten"  material="ZDC_Tungsten"     thickness="ZDC_Tungsten_thickness"  vis="AnlLight_Gray"/>
+        <slice name="glue"      material="G10"     thickness="ZDC_glue_thickness"  vis="AnlLight_Gray"/>
+        <slice name="silicon"   material="Silicon" thickness="ZDC_pixel_thickness"   vis="AnlRed"  sensitive="true"/>
+        <slice name="glue"      material="G10"     thickness="ZDC_glue_thickness"  vis="AnlLight_Gray"/>
+        <slice name="pcb"       material="ZDC_PET" thickness="ZDC_PCB_thickness"   vis="AnlGreen"/>
+      </layer>
+
+    </detector>
+  </detectors>
+
+  <readouts>
+    <readout name="IP8_ZDC_WSi_Hits">
+      <segmentation type="MultiSegmentation" key="silicon">
+        <segmentation name="WSi_Pixel1" type="CartesianGridXY" key_value="1" grid_size_x="3.*mm" grid_size_y="3.*mm"/>
+        <segmentation name="WSi_Pixel2" type="CartesianGridXY" key_value="12" grid_size_x="3.*mm" grid_size_y="3.*mm"/>
+        <segmentation name="WSi_Pixel3" type="CartesianGridXY" key_value="23" grid_size_x="3.*mm" grid_size_y="3.*mm"/>
+        <segmentation name="WSi_Pad1"   type="CartesianGridXY" key_min="2" key_max="11" grid_size_x="1.*cm" grid_size_y="1.*cm"/>
+        <segmentation name="WSi_Pad2"   type="CartesianGridXY" key_min="13" key_max="22" grid_size_x="1.*cm" grid_size_y="1.*cm"/>
+      </segmentation>
+      <id>system:8,silicon:6,x:24:-12,y:-12</id>
+    </readout>
+  </readouts>
+
+</lccdd>

--- a/compact/far_forward/ZDC_ip8.xml
+++ b/compact/far_forward/ZDC_ip8.xml
@@ -1,0 +1,93 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+<!-- Copyright (C) 2022 Shima Shimizu, Wouter Deconinck, Whitney Armstrong -->
+<!-- Modified based on IP-8 information Jihee Kim-->
+
+<lccdd>
+
+  <comment>Far Forward Hadron Detectors</comment>
+
+  <define>
+    <comment>
+      -------------------------------------------
+      Zero Degree Calorimeter General Parameters
+      -------------------------------------------
+    </comment>
+    <constant name="ZDC_r_pos"         value="3542.93 * cm"/> <!-- Make it match to the CAD figure 22/Nov/22 -->
+    <constant name="ZDC_x_pos"         value="0.0 * cm"/>  <!--14. *cm -->
+    <constant name="ZDC_y_pos"         value="0.0 * cm"/>
+    <constant name="ZDC_rotateX_angle" value="0.0 * rad"/>
+    <constant name="ZDC_rotateY_angle" value="ionCrossingAngle"/>
+    <constant name="ZDC_rotateZ_angle" value="0.0 * rad"/>
+    <constant name="ZDC_width"         value="60.0 * cm"/>
+    <constant name="ZDC_length"        value="200.0 * cm"/>
+
+    <comment>
+      -------------------------------
+      Zero Degree Calorimeter - ECAL
+      -------------------------------
+    </comment>
+    <constant name="ZDC_1stSilicon_r_pos"        value="ZDC_r_pos+0.5*cm"/>
+    <constant name="ZDC_1stSilicon_z_pos"        value="ZDC_1stSilicon_r_pos * cos(ionCrossingAngle)"/>
+    <constant name="ZDC_1stSilicon_x_pos"        value="ZDC_x_pos + ZDC_1stSilicon_r_pos * sin(ionCrossingAngle)"/>
+    <constant name="ZDC_1stSilicon_y_pos"        value="ZDC_y_pos"/>
+    <constant name="ZDC_1stSilicon_rotateX_angle"   value="ZDC_rotateX_angle"/>
+    <constant name="ZDC_1stSilicon_rotateY_angle"   value="ZDC_rotateY_angle"/>
+    <constant name="ZDC_1stSilicon_rotateZ_angle"   value="ZDC_rotateZ_angle"/>
+
+    <constant name="ZDC_Crystal_r_pos"           value="ZDC_r_pos + 5.9 *cm "/>
+    <constant name="ZDC_Crystal_z_pos"           value="ZDC_Crystal_r_pos * cos(ionCrossingAngle)"/>
+    <constant name="ZDC_Crystal_x_pos"           value="ZDC_x_pos + ZDC_Crystal_r_pos * sin(ionCrossingAngle)"/>
+    <constant name="ZDC_Crystal_y_pos"           value="ZDC_y_pos"/>
+    <constant name="ZDC_Crystal_rotateX_angle"   value="ZDC_rotateX_angle"/>
+    <constant name="ZDC_Crystal_rotateY_angle"   value="ZDC_rotateY_angle"/>
+    <constant name="ZDC_Crystal_rotateZ_angle"   value="ZDC_rotateZ_angle"/>
+    <constant name="ZDC_Crystal_width"           value="ZDC_width"/>
+
+    <constant name="ZDC_WSi_r_pos"               value="ZDC_r_pos + 23*cm"/>
+    <constant name="ZDC_WSi_z_pos"               value="ZDC_WSi_r_pos * cos(ionCrossingAngle)"/>
+    <constant name="ZDC_WSi_x_pos"               value="ZDC_x_pos + ZDC_WSi_r_pos * sin(ionCrossingAngle)"/>
+    <constant name="ZDC_WSi_y_pos"               value="ZDC_y_pos"/>
+    <constant name="ZDC_WSi_rotateX_angle"       value="ZDC_rotateX_angle"/>
+    <constant name="ZDC_WSi_rotateY_angle"       value="ZDC_rotateY_angle"/>
+    <constant name="ZDC_WSi_rotateZ_angle"       value="ZDC_rotateZ_angle"/>
+    <constant name="ZDC_WSi_nblocks"             value="2"/>
+    <constant name="ZDC_WSi_pad_nlayers_per_block"         value="10"/>
+
+    <constant name="ZDC_PbSi_r_pos"               value="ZDC_r_pos + 59. *cm"/>
+    <constant name="ZDC_PbSi_z_pos"               value="ZDC_PbSi_r_pos * cos(ionCrossingAngle)"/>
+    <constant name="ZDC_PbSi_x_pos"               value="ZDC_x_pos + ZDC_PbSi_r_pos * sin(ionCrossingAngle)"/>
+    <constant name="ZDC_PbSi_y_pos"               value="ZDC_y_pos"/>
+    <constant name="ZDC_PbSi_rotateX_angle"       value="ZDC_rotateX_angle"/>
+    <constant name="ZDC_PbSi_rotateY_angle"       value="ZDC_rotateY_angle"/>
+    <constant name="ZDC_PbSi_rotateZ_angle"       value="ZDC_rotateZ_angle"/>
+    <constant name="ZDC_PbSi_nlayers"             value="12"/>
+
+    <constant name="ZDC_PbSci_r_pos"               value="ZDC_r_pos + 137. *cm"/>
+    <constant name="ZDC_PbSci_z_pos"               value="ZDC_PbSci_r_pos * cos(ionCrossingAngle)"/>
+    <constant name="ZDC_PbSci_x_pos"               value="ZDC_x_pos + ZDC_PbSci_r_pos * sin(ionCrossingAngle)"/>
+    <constant name="ZDC_PbSci_y_pos"               value="ZDC_y_pos"/>
+    <constant name="ZDC_PbSci_rotateX_angle"       value="ZDC_rotateX_angle"/>
+    <constant name="ZDC_PbSci_rotateY_angle"       value="ZDC_rotateY_angle"/>
+    <constant name="ZDC_PbSci_rotateZ_angle"       value="ZDC_rotateZ_angle"/>
+    <constant name="ZDC_PbSci_nbox"                value="2"/>
+    <constant name="ZDC_PbSci_nlayers_per_box"     value="15"/>
+    <constant name="ZDC_PbSci_box_gap"             value="5.*cm"/>
+
+    <constant name="ZDC_pad_thickness"           value="320.0 * um"/>
+    <constant name="ZDC_pixel_thickness"         value="300.0 * um"/>
+    <constant name="ZDC_glue_thickness"          value="0.11 * mm"/>
+    <constant name="ZDC_PCB_thickness"           value="1.6 * mm"/>
+    <constant name="ZDC_Si_Air_thickness"        value="5. *mm"/>
+    <constant name="ZDC_Tungsten_thickness"      value="3.5 *mm"/>
+    <constant name="ZDC_Lead_thickness"          value="3. *cm"/>
+    <constant name="ZDC_Sci_thickness"           value="2.* mm"/>
+
+  </define>
+
+  <include ref="ZDC_1stSilicon_ip8.xml"/>
+  <include ref="ZDC_Crystal_ip8.xml"/>
+  <include ref="ZDC_WSi_ip8.xml"/>
+  <include ref="ZDC_PbSi_ip8.xml"/>
+  <include ref="ZDC_PbScinti_ip8.xml"/>
+
+</lccdd>

--- a/compact/far_forward/offM_tracker_ip8.xml
+++ b/compact/far_forward/offM_tracker_ip8.xml
@@ -1,0 +1,136 @@
+<!-- SPDX-License-Identifier: LGPL-3.0-or-later -->
+<!-- Copyright (C) 2022 Whitney Armstrong, Alex Jentsch -->
+<!-- Modified based on IP-8 information Jihee Kim-->
+
+<lccdd>
+  <define>
+    <comment>
+      ----------------------------------------
+      Forward Off-Momentum Tracker Parameters
+      ----------------------------------------
+    </comment>
+    <constant name="ForwardOffMTracker_zpos" value="BXDS01A_CenterPosition + BXDS01A_Length/2.0 + 10.0*cm"/>
+    <constant name="ForwardOffMTracker_xpos" value="BXDS01A_XPosition+40.0*cm"/>
+
+    <!-- Thicknesses -->
+    <constant name="ForwardOffMTracker_RFShieldThickness"          value="1.0*mm"/>
+    <constant name="ForwardOffMTracker_LGADThickness"              value="0.3*mm"/>
+    <constant name="ForwardOffMTracker_ASICThickness"              value="0.3*mm"/>
+    <constant name="ForwardOffMTracker_ThermalStripThickness"      value="0.3*mm"/>
+    <constant name="ForwardOffMTracker_ShieldingAirLayerThickness" value="0.3*mm"/>
+    <constant name="ForwardOffMTracker_LayerSeparationThickness" value="1.0*cm"/>
+
+  </define>
+
+  <detectors>
+
+    <detector
+      id="IP8_ForwardOffMTracker_station_1_ID"
+      name="ForwardOffMTracker_station_1"
+      type="ip6_OffMomentumTracker"
+      readout="IP8ForwardOffMTrackerHits"
+      vis="FFTrackerVis"
+      reflect="false">
+      <position x="0.673133*m" y="0" z="25.9359*m"/>
+      <rotation x="0.*rad" y="0.*rad" z="0.*rad"/>
+      <module name="OMD1Mod1" vis="FFTrackerShieldedModuleVis">
+        <shape x="20.0*cm" y="30.0*cm"/>
+        <comment> back-to-front </comment>
+        <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
+        <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardOffMTracker_ThermalStripThickness" />
+        <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardOffMTracker_ASICThickness"  />
+        <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardOffMTracker_LGADThickness" sensitive="true"/>
+        <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardOffMTracker_ShieldingAirLayerThickness"/>
+        <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
+      </module>
+      <layer id="1" module="OMD1Mod1">
+        <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="1.0*cm"
+          zstart="0.0/2.0" />
+      </layer>
+    </detector>
+
+    <detector
+      id="IP8_ForwardOffMTracker_station_2_ID"
+      name="ForwardOffMTracker_station_2"
+      type="ip6_OffMomentumTracker"
+      readout="IP8ForwardOffMTrackerHits"
+      vis="AnlRed"
+      reflect="false">
+      <position x="0.673353*m" y="0" z="25.9559*m"/>
+      <rotation x="0.*rad" y="0.*rad" z="0.*rad"/>
+      <module name="OMD2Mod1" vis="FFTrackerShieldedModuleVis">
+        <shape x="20.0*cm" y="30.0*cm"/>
+        <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
+        <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardOffMTracker_ThermalStripThickness" />
+        <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardOffMTracker_ASICThickness"  />
+        <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardOffMTracker_LGADThickness" sensitive="true"/>
+        <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardOffMTracker_ShieldingAirLayerThickness"/>
+        <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
+      </module>
+      <layer id="1" module="OMD2Mod1">
+         <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="3.2*mm"
+           zstart="0.0/2.0" />
+      </layer>
+
+    </detector>
+
+    <detector
+      id="IP8_ForwardOffMTracker_station_3_ID"
+      name="ForwardOffMTracker_station_3"
+      type="ip6_OffMomentumTracker"
+      readout="IP8ForwardOffMTrackerHits"
+      vis="FFTrackerVis"
+      reflect="false">
+      <position x="0.652435*m" y="0" z="27.9363*m"/>
+      <rotation x="0.*rad" y="0.*rad" z="0.*rad"/>
+      <module name="OMD3Mod1" vis="FFTrackerShieldedModuleVis">
+        <shape x="20.0*cm" y="30.0*cm"/>
+        <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
+        <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardOffMTracker_ThermalStripThickness" />
+        <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardOffMTracker_ASICThickness"  />
+        <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardOffMTracker_LGADThickness" sensitive="true"/>
+        <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardOffMTracker_ShieldingAirLayerThickness"/>
+        <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
+      </module>
+      <layer id="1" module="OMD3Mod1">
+         <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="3.2*mm"
+          zstart="0.0/2.0" />
+      </layer>
+
+    </detector>
+
+    <detector
+      id="IP8_ForwardOffMTracker_station_4_ID"
+      name="ForwardOffMTracker_station_4"
+      type="ip6_OffMomentumTracker"
+      readout="IP8ForwardOffMTrackerHits"
+      vis="FFTrackerVis"
+      reflect="false">
+      <position x="0.652655*m" y="0" z="27.9563*m"/>
+      <rotation x="0.*rad" y="0.*rad" z="0.*rad"/>
+      <module name="OMD4Mod1" vis="FFTrackerShieldedModuleVis">
+        <shape x="20.0*cm" y="30.0*cm"/>
+        <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
+        <module_component material="Copper"       vis="FFTrackerServiceVis"   thickness="ForwardOffMTracker_ThermalStripThickness" />
+        <module_component material="SiliconOxide" vis="FFTrackerServiceVis"   thickness="ForwardOffMTracker_ASICThickness"  />
+        <module_component material="SiliconOxide" vis="FFTrackerSurfaceVis"   thickness="ForwardOffMTracker_LGADThickness" sensitive="true"/>
+        <module_component material="Vacuum"       vis="InvisibleNoDaughters"  thickness="ForwardOffMTracker_ShieldingAirLayerThickness"/>
+        <module_component material="Aluminum"     vis="FFTrackerShieldingVis" thickness="ForwardOffMTracker_RFShieldThickness"/>
+      </module>
+      <layer id="1" module="OMD4Mod1">
+         <envelope vis="FFTrackerLayerVis" x="10.0*cm" y="20.0*cm" length="3.2*mm"
+          zstart="0.0/2.0" />
+      </layer>
+
+    </detector>
+
+  </detectors>
+
+  <readouts>
+    <readout name="IP8ForwardOffMTrackerHits">
+      <segmentation type="CartesianGridXY" grid_size_x="0.5*mm" grid_size_y="0.5*mm" />
+      <id>system:8,layer:5,module:5,slice:4,x:32:-16,y:-16</id>
+    </readout>
+  </readouts>
+
+</lccdd>

--- a/compact/far_forward_ip8.xml
+++ b/compact/far_forward_ip8.xml
@@ -7,5 +7,9 @@
   <include ref="far_forward/ion_beamline_ip8.xml" />
   <include ref="far_forward/magnets_ip8.xml"/>
   <include ref="far_forward/simple_roman_pots_secondary_focus_ip8.xml"/>
+  <include ref="far_forward/B0_tracker_ip8.xml"/>
+  <include ref="far_forward/B0_ECal_ip8.xml"/>
+  <include ref="far_forward/offM_tracker_ip8.xml"/>
+  <include ref="far_forward/ZDC_ip8.xml"/>
 
 </lccdd>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Added B0, OMD, and ZDC implementations
Checked detector acceptance using single particle simulations
- OMD 67.34% (672,682/999,000)
- B0 93.66% (936,611/1,000,000)
- ZDC 99.99% (499,299/499,360) up to 5 mrad

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #11 )
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No
![hAccB0Track](https://github.com/eic/D2EIC/assets/112661168/248d41a3-a634-43e1-ac53-54a4535b89d9)
![hAccOMD](https://github.com/eic/D2EIC/assets/112661168/d40b3198-8ee6-465c-9d86-ca0752faf103)
![hAccZDC](https://github.com/eic/D2EIC/assets/112661168/c97b6ed6-28d6-4be8-8b72-6bc0a415c41a)
